### PR TITLE
I'd like you to consider supporting an endpoint that can send custom headers.

### DIFF
--- a/googp.go
+++ b/googp.go
@@ -7,7 +7,6 @@
 // OGP: https://ogp.me
 //
 // Source code: https://github.com/soranoba/googp
-//
 package googp
 
 import (
@@ -23,6 +22,19 @@ import (
 // Fetch the content from the URL and parse OGP information.
 func Fetch(rawurl string, i interface{}, opts ...ParserOpts) error {
 	res, err := http.Get(rawurl)
+	if err != nil {
+		return fmt.Errorf("Failed to get the content: %w", err)
+	}
+	return Parse(res, i, opts...)
+}
+
+func FetchWithHeader(rawurl string, i interface{}, header http.Header, opts ...ParserOpts) error {
+	req, err := http.NewRequest("GET", rawurl, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to get the content: %w", err)
+	}
+	req.Header = header
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Failed to get the content: %w", err)
 	}


### PR DESCRIPTION
This is intended for use in cases where the default UserAgent for golang is denied on websites under rules such as WAF.

Here's an example:


```golang
func TestFetchWithHeader(t *testing.T) {
	// URL is embedded url.URL and is added TextUnmarshaler implementation.
	var _ encoding.TextUnmarshaler = &URL{}

	type MyOGP struct {
		Title    string `googp:"og:title"`
		URL      URL    `googp:"og:url"`
		ImageURL *URL   `googp:"og:image"`
		AppID    int    `googp:"fb:app_id"`
	}

	var ogp MyOGP
	var h = http.Header{}
	h.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0")
	if err := FetchWithHeader("https://example.com", &ogp, h); err != nil {
		return
	}
}
```

Please consider it.
